### PR TITLE
Added callbacks for custom sorting

### DIFF
--- a/src/Jedrzej/Sortable/Criterion.php
+++ b/src/Jedrzej/Sortable/Criterion.php
@@ -50,7 +50,13 @@ class Criterion
      */
     public function apply(Builder $builder)
     {
-        $builder->orderBy($this->getField(), $this->getOrder());
+        $sortMethod = 'sort' . studly_case($this->getField());
+
+        if(method_exists($builder->getModel(), $sortMethod)) {
+            call_user_func_array([$builder->getModel(), $sortMethod], [$builder, $this->getOrder()]);
+        } else {
+            $builder->orderBy($this->getField(), $this->getOrder());
+        }
     }
 
     /**

--- a/tests/unit/SortableTraitTest.php
+++ b/tests/unit/SortableTraitTest.php
@@ -60,5 +60,12 @@ class SortableTraitTest extends Test
             $this->assertEquals('field2', $criteria[0]['column']);
             $this->assertEquals('field42', $criteria[1]['column']);
         });
+
+        $this->specify('available callback method is used in lieu of standard sorting', function() {
+            $criteria = (array)TestModelWithSortableCallbackMethod::sorted(['name,desc'])->getQuery()->orders;
+
+            $this->assertEquals('real_name', $criteria[0]['column']);
+            $this->assertEquals('desc', $criteria[0]['direction']);
+        });
     }
 }

--- a/tests/unit/TestModelWithSortableCallbackMethod.php
+++ b/tests/unit/TestModelWithSortableCallbackMethod.php
@@ -1,0 +1,18 @@
+<?php
+
+class TestModelWithSortableCallbackMethod extends TestModel
+{
+    protected $sortable = ['name'];
+
+    /**
+     * Sorts by the "real_name" field.  Accessed by sorting "name".
+     *
+     * @param $query
+     * @param string $direction
+     * @return mixed
+     */
+    public function sortName($query, $direction = 'desc')
+    {
+        return $query->orderBy('real_name', $direction);
+    }
+}

--- a/tests/unit/_bootstrap.php
+++ b/tests/unit/_bootstrap.php
@@ -4,4 +4,5 @@ require_once 'TestModel.php';
 require_once 'TestModelWithAllFieldsSortable.php';
 require_once 'TestModelWithSortableMethod.php';
 require_once 'TestModelWithSortableProperty.php';
+require_once 'TestModelWithSortableCallbackMethod.php';
 require_once 'TestBuilder.php';


### PR DESCRIPTION
By adding a `sort[FieldName]` method to a `Sortable` model, one can customize the query used when sorting is applied to that field:

``` php
public function sortField($query, $direction = 'desc') {
    return $query->orderBy('field', $direction);
}
```
