### PR TITLE
Update for Laravel 6.0 Remove deprecated helper function and use Facade

### DIFF
--- a/src/Jedrzej/Sortable/Criterion.php
+++ b/src/Jedrzej/Sortable/Criterion.php
@@ -1,6 +1,7 @@
 <?php namespace Jedrzej\Sortable;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class Criterion
@@ -53,7 +54,7 @@ class Criterion
      */
     public function apply(Builder $builder)
     {
-        $sortMethod = 'sort' . studly_case($this->getField());
+        $sortMethod = 'sort' . Str::studly($this->getField());
 
         if(method_exists($builder->getModel(), $sortMethod)) {
             call_user_func_array([$builder->getModel(), $sortMethod], [$builder, $this->getOrder()]);

--- a/src/Jedrzej/Sortable/SortableTrait.php
+++ b/src/Jedrzej/Sortable/SortableTrait.php
@@ -1,7 +1,6 @@
 <?php namespace Jedrzej\Sortable;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\Input;
 use RuntimeException;
 
 trait SortableTrait
@@ -16,7 +15,7 @@ trait SortableTrait
      */
     public function scopeSorted(Builder $builder, $query = [])
     {
-        $query = (array)($query ?: Input::input($this->_getSortParameterName(), $this->_getDefaultSortCriteria()));
+        $query = (array)($query ?: request()->input($this->_getSortParameterName(), $this->_getDefaultSortCriteria()));
 
         if (empty($query)) {
             $query = $this->_getDefaultSortCriteria();


### PR DESCRIPTION
Update for Laravel 6.0

Use Arr Class instead of deprecated function array_*

The Input facade, which was primarily a duplicate of the Request facade, has been removed. Use request() helper method instead of Input Class.

https://laravel.com/docs/6.0/upgrade